### PR TITLE
correct List init in Stack.h

### DIFF
--- a/src/Stack.h
+++ b/src/Stack.h
@@ -22,7 +22,7 @@ class Stack
         if (new_head)
         {
             auto tail = deep_copy_list(new_head->next);
-            return (new List(new_head->data, tail));
+            return (new List{new_head->data, tail}); // struct init -> {}
         }
 
         return (nullptr);


### PR DESCRIPTION
List is a Plain Old Data struct and hence has no constructors -> aggregate initialization via {} is required.
deep_copy_list is never called as is but is useful for Stacks, where the initialization issue caused some confusion among students.